### PR TITLE
set PIXI SPRITE_MAX_TEXTURES

### DIFF
--- a/js/canvas.js
+++ b/js/canvas.js
@@ -180,7 +180,8 @@ function Canvas() {
             imageSize3 = config.loader.textures.big.size;
         }
 
-        PIXI.settings.SCALE_MODE = 1
+        PIXI.settings.SCALE_MODE = 1;
+        PIXI.settings.SPRITE_MAX_TEXTURES = Math.min(PIXI.settings.SPRITE_MAX_TEXTURES , 16);
 
         var renderOptions = {
             resolution: 1,


### PR DESCRIPTION
To avoid PIXI initiation crash when the client is Firefox and Linux.
https://github.com/pixijs/pixi.js/issues/4478