### PR TITLE
Fixed word-wrap in the left sidebar that renders info.md

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,7 +150,7 @@ cpietsch@gmail.com
       <div class="outer">
         <div class="inner">
           <div id="infobar" class="infosidebar">
-            <span v-html="marked(info)"></span>
+            <span v-html="marked(info)" style="word-break: normal; white-space: pre-wrap;"></span>
             <div class="credit">
               Powered by
               <a href="https://vikusviewer.fh-potsdam.de/" target="_blank">VIKUS Viewer</a>


### PR DESCRIPTION
Word-breaks in the info-sidebar seem to behave weirdly:
<img width="391" alt="image" src="https://github.com/cpietsch/vikus-viewer/assets/34612138/781dbaba-745b-4531-8797-fa2eda5417d5">

Setting the styles on the marked()-span explicitely fixes the problem for me:
`<span v-html="marked(info)" style="word-break: normal; white-space: pre-wrap;"></span>`
